### PR TITLE
update metadata to point to this library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # taskcluster-lib-log
 
-A small configuration wrapper around Bunyan logging.  This module's main
+A configuration wrapper around Bunyan logging.  This module's main
 purpose is to contain all the taskcluster boiler plate and configuration logic
 around logging with Bunyan.
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,8 @@
 {
   "name": "taskcluster-lib-log",
   "version": "2.0.1",
-  "description": "Configure bunyan log levels from Environment like debug",
+  "description": "A configuration wrapper around Bunyan logging",
   "main": "lib/log.js",
-  "bin": {
-    "bunyan": "./node_modules/bunyan/bin/bunyan"
-  },
   "files": [
     "src",
     "lib"
@@ -20,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/taskcluster/bunyan-env-config.git"
+    "url": "git+https://github.com/taskcluster/taskcluster-lib-log.git"
   },
   "keywords": [
     "taskcluster",


### PR DESCRIPTION
I noticed that the repo was wrong in the npmjs.com display.

I think the bin is supplied by bunyan, and doesn't need to be supplied by this module.  At least that's the case in my testing (cloned this repo to a clean directory, `yarn`, saw bunyan in `./node_modules/.bin`).