### PR TITLE
Add the standard 'err' serializer

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,11 @@ function setupLogger(name, cfg) {
   let envLevel = parseEnvironment(process.env.LOG_LEVEL, cfg);
   let oldLevel = cfg.level;
   cfg.level = envLevel;
+
+  cfg.serializers = {
+    err: bunyan.stdSerializers.err,
+  };
+
   let logger = bunyan.createLogger(cfg);
 
   // But let's make it clear that we did this by logging


### PR DESCRIPTION
I thought this was already done, but this lets us do:

```js
log = require('./')('testing');
log.error({err: new Error('xyz'), prop1: 'val1'}, 'with extra properties');
log.error(new Error('abc'), 'and without');
```
and when run through `bunyan -o short`, get nice output:
```
$ node file.js | bunyan -o short
10:26:44.234Z ERROR testing: with extra properties (prop1=val1)
    Error: xyz
        at Object.<anonymous> (/home/jhford/taskcluster/taskcluster-lib-log/la.js:2:17)
        at Module._compile (module.js:635:30)
        at Object.Module._extensions..js (module.js:646:10)
        at Module.load (module.js:554:32)
        at tryModuleLoad (module.js:497:12)
        at Function.Module._load (module.js:489:3)
        at Function.Module.runMain (module.js:676:10)
        at startup (bootstrap_node.js:187:16)
        at bootstrap_node.js:608:3
10:26:44.235Z ERROR testing: and without
    Error: abc
        at Object.<anonymous> (/home/jhford/taskcluster/taskcluster-lib-log/la.js:3:11)
        at Module._compile (module.js:635:30)
        at Object.Module._extensions..js (module.js:646:10)
        at Module.load (module.js:554:32)
        at tryModuleLoad (module.js:497:12)
        at Function.Module._load (module.js:489:3)
        at Function.Module.runMain (module.js:676:10)
        at startup (bootstrap_node.js:187:16)
        at bootstrap_node.js:608:3

```